### PR TITLE
Update rpc message decoding

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -12,7 +12,8 @@ class Controller:
 
     def incoming(self,body):
         #handles new rpc calls
-        request_body = base64.b64decode(body).decode("utf-8")
+        print(body)
+        request_body = body.decode("utf-8")
         auth_code = json.loads(request_body)['auth_code']
         print(auth_code)
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-httplib2==0.9.2
+httplib2==0.10.3
+pika==0.10.0
 psycopg2==2.7
 google_api_python_client==1.6.2


### PR DESCRIPTION
Because of a change with the client api, US need to decode the message differently now.